### PR TITLE
Add GitHub Actions workflows for building releases and for releasing for ARM

### DIFF
--- a/.github/workflows/dmkdump-build.yml
+++ b/.github/workflows/dmkdump-build.yml
@@ -1,0 +1,133 @@
+#
+# Build releases of dmkdump for all supported platforms and upload
+# their release artifacts.
+#
+
+name: Build dmkdump
+
+on:
+  workflow_dispatch:
+    inputs:
+      make_build_target:
+        description: Make build target
+        required: false
+        type: string
+        default: "release"
+      container_base:
+        description: Base path for containers
+        required: false
+        type: string
+        default: "ghcr.io/qbarnes/containers-for-cross-compiling"
+
+  workflow_call:
+    inputs:
+      make_build_target:
+        description: Make build target
+        required: false
+        type: string
+        default: "release"
+      container_base:
+        description: Base path for containers
+        required: false
+        type: string
+        default: "ghcr.io/qbarnes/containers-for-cross-compiling"
+    outputs:
+      package_name:
+        description: Name of package
+        value: ${{ jobs.build_all.outputs.package_name }}
+      package_version:
+        description: Build version
+        value: ${{ jobs.build_all.outputs.package_version }}
+
+
+jobs:
+  build_name_version:
+    name: Determine Build Package Name and Version
+    runs-on: ubuntu-latest
+    outputs:
+      package_name: ${{ steps.package_and_version.outputs.package_name }}
+      package_version: ${{ steps.package_and_version.outputs.package_version }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+
+      - id: package_and_version
+        run: |
+          echo "package_name=$(make show_package)" >> $GITHUB_OUTPUT
+          echo "package_version=$(make show_version)" >> $GITHUB_OUTPUT
+
+
+  build_platform:
+    runs-on: ubuntu-latest
+    needs: build_name_version
+    outputs:
+      build_artifacts_name: ${{ steps.build_artifacts_name.outputs.build_artifacts_name }}
+    env:
+      package: ${{ needs.build_name_version.outputs.package_name }}
+      version: ${{ needs.build_name_version.outputs.package_version }}
+      target_platform_full_name: ${{ matrix.target_platform_name }}${{ matrix.target_arch }}
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [linux_x86_64, linux_armv7l, linux_aarch64, msdos, mswin32, mswin64]
+        include:
+          - platform: linux_x86_64
+            target_platform_name: linux
+            target_platform: LINUX_X86_64
+            target_arch: .x86_64
+          - platform: linux_armv7l
+            container: ${{ inputs.container_base }}/ubuntu-20.04-crossbuild-armv7l
+            target_platform_name: linux
+            target_platform: LINUX_ARMV7L
+            target_arch: .armv7l
+          - platform: linux_aarch64
+            container: ${{ inputs.container_base }}/ubuntu-20.04-crossbuild-aarch64
+            target_platform_name: linux
+            target_platform: LINUX_AARCH64
+            target_arch: .aarch64
+          - platform: msdos
+            container: ${{ inputs.container_base }}/ubuntu-22.04-crossbuild-msdos
+            target_platform_name: msdos
+            target_platform: MSDOS
+          - platform: mswin32
+            container: ${{ inputs.container_base }}/ubuntu-22.04-crossbuild-mswindows
+            target_platform_name: win32
+            target_platform: MSWIN32
+          - platform: mswin64
+            container: ${{ inputs.container_base }}/ubuntu-22.04-crossbuild-mswindows
+            target_platform_name: win64
+            target_platform: MSWIN64
+    container:
+      image: ${{ matrix.container }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+
+      - name: Build target
+        id: build_target
+        run: |
+          make -f Makefile.cross \
+            "BUILDS=${{ matrix.target_platform }}" "${{ inputs.make_build_target }}"
+          echo "build_artifacts_name=${package}-${version}-${target_platform_full_name}-build-artifacts" >> $GITHUB_OUTPUT
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ steps.build_target.outputs.build_artifacts_name }}
+          path: build.${{ env.target_platform_full_name }}/${{ env.package }}-${{ env.version }}-${{ env.target_platform_full_name }}.tar.gz
+          if-no-files-found: error
+          retention-days: 2
+
+
+  build_all:
+    name: Build All
+    runs-on: ubuntu-latest
+    needs: [build_name_version, build_platform]
+    outputs:
+      package_name: ${{ needs.build_name_version.outputs.package_name }}
+      package_version: ${{ needs.build_name_version.outputs.package_version }}
+    steps:
+      - name: Build All Done
+        run: echo 'Build All' done!

--- a/.github/workflows/dmkdump-release.yml
+++ b/.github/workflows/dmkdump-release.yml
@@ -1,0 +1,75 @@
+#
+# Call dmkdump-build to make build artifacts, release those
+# artifacts for all supported platforms, tag the build from
+# product.mk's VERSION, and publish the new release.
+#
+# If a "release_description" file exists in one of the release
+# tarballs, use its contents for the release description text,
+# otherwise, remember to edit the release yourself and update its
+# description.
+#
+
+name: Release dmkdump
+
+on:
+  workflow_dispatch:
+
+
+jobs:
+  call_build:
+    uses: ./.github/workflows/dmkdump-build.yml
+    with:
+      make_build_target: "release"
+    secrets: inherit
+
+
+  release:
+    name: Make Release
+    needs: call_build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Show package name and version
+        run: |
+          echo needs.call_build.outputs.package_name=${{ needs.call_build.outputs.package_name }}
+          echo needs.call_build.outputs.package_version=${{ needs.call_build.outputs.package_version }}
+
+      - name: Make artifacts directory
+        run: mkdir github_artifacts
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v3
+        with:
+          path: github_artifacts
+
+      - name: Show downloaded artifacts
+        run: ls -lR github_artifacts
+
+      - name: Find release description, if any
+        id: rel_desc_files
+        shell: bash
+        run: |
+          shopt -s nullglob
+          rel_desc_files=(github_artifacts/*/release_description)
+          rel_desc_file="${rel_desc_files[0]}" >> $GITHUB_OUTPUT
+
+      - name: Show release description file, if any
+        run: echo "rel_desc_file=${{ steps.rel_desc_files.output.rel_desc_file }}"
+
+      - name: Create tag for release
+        uses: rickstaa/action-create-tag@v1
+        with:
+          tag: "v${{ needs.call_build.outputs.package_version }}"
+
+      - name: Publish release
+        uses: ncipollo/release-action@v1
+        with:
+          artifactErrorsFailBuild: true
+          makeLatest: true
+          name: "Release ${{ needs.call_build.outputs.package_version }}"
+          tag: "v${{ needs.call_build.outputs.package_version }}"
+          bodyFile: "${{ steps.rel_desc_files.output.rel_desc_file }}"
+          artifacts: github_artifacts/*/*.tar.gz

--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,12 @@ $(TARBALLGZ): $(tar_files)
 		--transform='s:^cwsdpmi/bin/CWSDPMI.EXE:cwsdpmi.exe:' \
 		-f '$@' $^
 
+show_package:
+	@echo $(PRODUCT)
 
-.PHONY: all release clean clobber distclean FORCE
+show_version:
+	@echo $(VERSION)
+
+
+.PHONY: all release clean clobber distclean show_package show_version FORCE
 .DELETE_ON_ERROR:

--- a/Makefile.cross
+++ b/Makefile.cross
@@ -1,12 +1,28 @@
 include defines.mk product.mk
 
-TARGET_OS ?= NATIVE
-build_dir  = build
+build_dir  ?= build
 
 linux_targets = $(PRODUCT)
 ms_targets    = $(PRODUCT).exe
 
-BUILDS    ?= NATIVE MSDOS MSWIN32 MSWIN64
+BUILDS    ?= LINUX_X86_64 LINUX_ARMV7L LINUX_AARCH64 MSDOS MSWIN32 MSWIN64
+
+native_os   := $(shell uname -o)
+native_arch := $(shell uname -m)
+
+LINUX_X86_64_CC  ?= x86_64-linux-gnu-gcc
+LINUX_ARMV7L_CC  ?= arm-linux-gnueabi-gcc
+LINUX_AARCH64_CC ?= aarch64-linux-gnu-gcc
+
+ifeq ($(native_os),GNU/Linux)
+  ifeq ($(native_arch),x86_64)
+    LINUX_X86_64_CC  = $(CC)
+  else ifeq ($(native_arch),armv7l)
+    LINUX_ARMV7L_CC  = $(CC)
+  else ifeq ($(native_arch),aarch64)
+    LINUX_AARCH64_CC = $(CC)
+  endif
+endif
 
 define cross_settings
 $(eval $(1)_cross_os        = $(2))
@@ -20,18 +36,18 @@ $(eval $(1)_tar_extras      = $(if $(subst msdos,,$(2)),,CWSDPMI.EXE))
 $(eval $(1)_release_targz   = $(patsubst %.tar.gz,%,$(TARBALLGZ))-$(5).tar.gz)
 endef
 
-$(call cross_settings,NATIVE,linux,\
-			$(shell arch),$$(CC),$$(NATIVE_dir_suffix))
-$(call cross_settings,LINUX_ARM,linux,\
-			armv7l,arm-linux-gnu-gcc,$$(LINUX_ARM_dir_suffix))
-$(call cross_settings,MSDOS,msdos,\
-			x86,i586-pc-msdosdjgpp-gcc,$$(MSDOS_cross_os))
+$(call cross_settings,LINUX_X86_64,linux,x86_64,\
+			$(LINUX_X86_64_CC),$$(LINUX_X86_64_dir_suffix))
+$(call cross_settings,LINUX_ARMV7L,linux,armv7l,\
+			$(LINUX_ARMV7L_CC),$$(LINUX_ARMV7L_dir_suffix))
+$(call cross_settings,LINUX_AARCH64,linux,aarch64,\
+			$(LINUX_AARCH64_CC),$$(LINUX_AARCH64_dir_suffix))
+$(call cross_settings,MSDOS,msdos,x86,\
+			i586-pc-msdosdjgpp-gcc,$$(MSDOS_cross_os))
 $(call cross_settings,MSWIN32,win,x86,\
 			i686-w64-mingw32-gcc,$$(MSWIN32_cross_os)32)
 $(call cross_settings,MSWIN64,win,x64,\
 			x86_64-w64-mingw32-gcc,$$(MSWIN64_cross_os)64)
-
-NATIVE_CC  = $(CC)
 
 BUILD_CMD_call = $(MAKE) \
 		CC='$($(1)_cross_cc)' \
@@ -45,11 +61,8 @@ BUILD_CMD_call = $(MAKE) \
 
 
 all release clean clobber distclean:
-	$(call BUILD_CMD_call,$(TARGET_OS)) '$@'
-
-fullrelease:
-	$(foreach v,$(BUILDS),$(call BUILD_CMD_call,$v) release$(nl))
+	$(foreach v,$(BUILDS),$(call BUILD_CMD_call,$v) '$@'$(nl))
 
 
-.PHONY: all release fullrelease clean clobber distclean
+.PHONY: all release clean clobber distclean
 .DELETE_ON_ERROR:


### PR DESCRIPTION
Add GitHub Actions workflows for building, tagging, and releasing new builds.

Add release support for ARM 32-bit (armv7l) and 64-bit (aarch64) binaries.